### PR TITLE
Enable Quality Priority camera noise reduction

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -262,7 +262,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     persist.camera.HAL3.enabled=0 \
     persist.camera.gyro.disable=1 \
     persist.camera.feature.cac=0 \
-    persist.camera.ois.disable=0
+    persist.camera.ois.disable=0 \
+    persist.denoise.process.plates=0
 
 # Sensors debug
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
Default camera denoise mode is prop 2 = WAVELET_DENOISE_STREAMLINE_YCBCR (Color & Luma - Speed Priority)
prop 0 = WAVELET_DENOISE_YCBCR_PLANE (Color & Luma - Quality Priority)